### PR TITLE
Fix - Canvas broken on RTL

### DIFF
--- a/app/src/main/java/com/clwater/compose_canvas/clap/ClapActivity.kt
+++ b/app/src/main/java/com/clwater/compose_canvas/clap/ClapActivity.kt
@@ -41,7 +41,9 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.input.pointer.pointerInteropFilter
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.core.animation.addListener
 import com.clwater.compose_canvas.R
@@ -69,7 +71,9 @@ class ClapActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    Clap()
+                    CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                        Clap()
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/clwater/compose_canvas/sun_moon/Canvas1Activity.kt
+++ b/app/src/main/java/com/clwater/compose_canvas/sun_moon/Canvas1Activity.kt
@@ -22,7 +22,9 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.core.animation.addListener
 import androidx.core.animation.doOnEnd
@@ -95,7 +97,9 @@ class Canvas1Activity : ComponentActivity() {
                             modifier = Modifier.fillMaxWidth(1f),
                             horizontalArrangement = Arrangement.Center,
                         ) {
-                            Canvas_1()
+                            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                                Canvas_1()
+                            }
                         }
                         Slider(
                             value = model.progress.value,

--- a/app/src/main/java/com/clwater/compose_canvas/tree/TreeActivity.kt
+++ b/app/src/main/java/com/clwater/compose_canvas/tree/TreeActivity.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -48,7 +49,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.clwater.compose_canvas.ui.theme.AndroidComposeCanvasTheme
 import kotlinx.coroutines.delay
@@ -217,9 +220,10 @@ class TreeActivity : ComponentActivity() {
                     .fillMaxWidth(),
                 contentAlignment = Alignment.Center
             ) {
-                TreeCanvas(seed, season)
+                CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                    TreeCanvas(seed, season)
+                }
             }
-
 
             Column {
                 Button(onClick = {


### PR DESCRIPTION
Hello! Thanks for the awesome project!

### Problem 
The views don't work well on RTL Languages, here's how they look.

| Clap  | Tree | Moon |
| ------------- | ------------- | ------------- |
| <img src="https://github.com/clwater/AndroidComposeCanvas/assets/20628286/dd2f2bec-0776-48a6-af3f-56bd415fd8b2" width="200"> | <img src="https://github.com/clwater/AndroidComposeCanvas/assets/20628286/a598f0c2-1b90-4c94-87fb-fa94efd28b00" width="200"> | <img src="https://github.com/clwater/AndroidComposeCanvas/assets/20628286/fedcfa47-9b57-4816-846a-39d035170af8" width="200">

### Solution

Wrap the canvas section only with CompositionLocalProvider (CLP) of Layout Direction, to force LTR view when drawing.

The sliders and other views are flipped by convention, and this is considered normal, so no need to wrap other views in CLP.

### Result

| Clap - After | Tree - After | Moon - After |
| ------------- | ------------- | ------------- |
| <img src="https://github.com/clwater/AndroidComposeCanvas/assets/20628286/c6e52e93-03b7-4480-942e-f7121768c719" width="200"> | <img src="https://github.com/clwater/AndroidComposeCanvas/assets/20628286/f5e4b876-71ec-4a99-b72f-95fb15893f37" width="200"> | <img src="https://github.com/clwater/AndroidComposeCanvas/assets/20628286/f48d2710-39c5-4e9e-b8ad-2e95fa4813fd" width="200">
